### PR TITLE
fix: header missing image

### DIFF
--- a/frontend/src/components/Header.js
+++ b/frontend/src/components/Header.js
@@ -38,7 +38,7 @@ const LoggedInView = (props) => {
       <li className="nav-item">
         <Link to={`/@${props.currentUser.username}`} className="nav-link">
           <img
-            src={props.currentUser.image}
+            src={"./placeholder.png"}
             className="user-pic pr-1"
             alt={props.currentUser.username}
           />

--- a/frontend/src/components/Header.js
+++ b/frontend/src/components/Header.js
@@ -38,7 +38,7 @@ const LoggedInView = (props) => {
       <li className="nav-item">
         <Link to={`/@${props.currentUser.username}`} className="nav-link">
           <img
-            src={"./placeholder.png"}
+            src="./placeholder.png"
             className="user-pic pr-1"
             alt={props.currentUser.username}
           />


### PR DESCRIPTION
# Description

Use `placeholder.png` to replace the missing image.

close #3 

## Screenshot

<img width="374" alt="截圖 2022-11-20 下午5 30 30" src="https://user-images.githubusercontent.com/67775387/202895126-659ea7f8-8487-4537-8985-f8ddd1866d04.png">
